### PR TITLE
Update link to Uchiwa docs

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -55,7 +55,7 @@
         <ul class="nav navbar-nav">
           <li><a href="/">HOME</a></li>
           <li><a href="#features">FEATURES</a></li>
-          <li><a href="https://docs.uchiwa.io">DOCS</a></li>
+          <li><a href="https://docs.sensu.io/uchiwa/latest/">DOCS</a></li>
           <li><a href="#support">SUPPORT</a></li>
           <li><a href="#download">DOWNLOAD</a></li>
           <li><a href="https://twitter.com/uchiwaio" target="_blank"><i class="fa fa-twitter-square fa-2x"></i></a></li>


### PR DESCRIPTION
Current link points to a docs mirror at docs.uchiwa.io. This change would update the docs link on uchiwa.io to https://docs.sensu.io/uchiwa/latest/.